### PR TITLE
Switch API database provider to PostgreSQL

### DIFF
--- a/pzi-api/PziApi/Program.cs
+++ b/pzi-api/PziApi/Program.cs
@@ -161,9 +161,9 @@ internal class Program
 
     builder.Services.AddDbContext<PziDbContext>((provider, options) =>
     {
-      options.UseSqlServer(builder.Configuration.GetConnectionString("Default"), sqlServerOptionsAction: sqlOptions =>
+      options.UseNpgsql(builder.Configuration.GetConnectionString("Default"), npgsqlOptionsAction: npgsqlOptions =>
       {
-        sqlOptions.CommandTimeout(240);
+        npgsqlOptions.CommandTimeout(240);
       });
     });
 

--- a/pzi-api/PziApi/PziApi.csproj
+++ b/pzi-api/PziApi/PziApi.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Odata" Version="9.3.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.5" />
     <PackageReference Include="NSwag.AspNetCore" Version="14.4.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />

--- a/pzi-api/README.md
+++ b/pzi-api/README.md
@@ -9,6 +9,7 @@ API project that powers PZI backend.
 - To configure database connection for local development, it is preferred to use `user-secrets` provided by .net framework. They can be set from Vistual Stuio UI or from command line:
   - `dotnet user-secrets set "ConnectionStrings:Default" "<<VALUE>>"`
 - We generally use shared instance of database (managing imported data is quite difficult to have per-user DBs), value for connection string can be provided on-demand.
+- The API now targets a PostgreSQL backend. Ensure the connection string you provide uses the PostgreSQL format (for example, `Host=localhost;Port=5432;Database=pzi;Username=pzi;Password=secret`).
 
 ## Configuration values for container
 


### PR DESCRIPTION
## Summary
- replace the SQL Server EF Core provider with the PostgreSQL provider
- update the database context configuration to use UseNpgsql with an equivalent command timeout
- document the PostgreSQL connection string requirements for local development

## Testing
- `dotnet test pzi-api/pzi-api.sln` *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfbb729c48321ae2de010ef42fee5